### PR TITLE
 Bugfix: Reversed gripper joint state

### DIFF
--- a/blue_hardware_interface/src/blue_kinematics.cpp
+++ b/blue_hardware_interface/src/blue_kinematics.cpp
@@ -65,13 +65,20 @@ void BlueKinematics::init(
           transmission_actuator_ratios,
           transmission_gear_ratios);
       joints_in_transmission = 2;
+    } else if (joint_idx == 0){
+        // Base roll joint
+        transmissions_[transmission_idx] = new ti::SimpleTransmission(
+            -gear_ratios[joint_idx],
+            0.0);
+        joints_in_transmission = 1;
     } else {
-      // Not differential pair (base or gripper, one joint each)
-      transmissions_[transmission_idx] = new ti::SimpleTransmission(
-          -gear_ratios[joint_idx],
-          0.0);
-      joints_in_transmission = 1;
+        // Gripper Joint
+        transmissions_[transmission_idx] = new ti::SimpleTransmission(
+            gear_ratios[joint_idx],
+            0.0);
+        joints_in_transmission = 1;
     }
+
 
     // Wrap raw data for each joint in the transmission
     for (int i = 0; i < joints_in_transmission; i++) {


### PR DESCRIPTION
### Description
In a recent update to the kinematics driver file, all reversed joint states for the joint_state_publisher for the Blue arm were fixed except for the gripper joint.

This patch fixes that bug.

### Expected behaviour
When the gripper is manually closed, the joint state and robot model in RViz should reflect the change. Likewise when it is open.

### Observed behaviour
When the gripper is manually **closed**, RViz shows that the gripper is actually **opening** way past its joint limits instead. This is due to a missing negative sign for the gripper joint state reporter as defined in the kinematics library.