### PR TITLE
Better controller gains

### DIFF
--- a/blue_controllers/config/controllers.yaml
+++ b/blue_controllers/config/controllers.yaml
@@ -53,13 +53,13 @@ joint_trajectory_controller:
       trajectory: 0.5
       goal: 0.02
   gains:
-    $(arg side)_base_roll_joint: {p: 75, i: 0, d: 5}
-    $(arg side)_shoulder_lift_joint: {p: 75, i: 0, d: 5}
-    $(arg side)_shoulder_roll_joint: {p: 75, i: 0, d: 5}
-    $(arg side)_elbow_lift_joint: {p: 75, i: 0, d: 5}
-    $(arg side)_elbow_roll_joint: {p: 75, i: 0, d: 5}
-    $(arg side)_wrist_lift_joint: {p: 75, i: 0, d: 5}
-    $(arg side)_wrist_roll_joint: {p: 75, i: 0, d: 5}
+    $(arg side)_base_roll_joint: {p: 40, i: 3, d: 3.5, i_clamp_min: -100, i_clamp_max: 100}
+    $(arg side)_shoulder_lift_joint: {p: 30, i: 3, d: 5, i_clamp_min: -30, i_clamp_max: 30}
+    $(arg side)_shoulder_roll_joint: {p: 30, i: 5, d: 4, i_clamp_min: -50, i_clamp_max: 50}
+    $(arg side)_elbow_lift_joint: {p: 30, i: 3, d: 5, i_clamp_min: -10, i_clamp_max: 10}
+    $(arg side)_elbow_roll_joint: {p: 20, i: 7, d: 3, i_clamp_min: -50, i_clamp_max: 50}
+    $(arg side)_wrist_lift_joint: {p: 20, i: 3, d: 2, i_clamp_min: -10, i_clamp_max: 10}
+    $(arg side)_wrist_roll_joint: {p: 15, i: 5, d: 1, i_clamp_min: -50, i_clamp_max: 50}
 
 joint_torque_controller:
   type: effort_controllers/JointGroupEffortController

--- a/blue_controllers/config/controllers.yaml
+++ b/blue_controllers/config/controllers.yaml
@@ -53,13 +53,13 @@ joint_trajectory_controller:
       trajectory: 0.5
       goal: 0.02
   gains:
-    $(arg side)_base_roll_joint: {p: 40, i: 3, d: 3.5, i_clamp_min: -100, i_clamp_max: 100}
-    $(arg side)_shoulder_lift_joint: {p: 30, i: 3, d: 5, i_clamp_min: -30, i_clamp_max: 30}
-    $(arg side)_shoulder_roll_joint: {p: 30, i: 5, d: 4, i_clamp_min: -50, i_clamp_max: 50}
-    $(arg side)_elbow_lift_joint: {p: 30, i: 3, d: 5, i_clamp_min: -10, i_clamp_max: 10}
-    $(arg side)_elbow_roll_joint: {p: 20, i: 7, d: 3, i_clamp_min: -50, i_clamp_max: 50}
-    $(arg side)_wrist_lift_joint: {p: 20, i: 3, d: 2, i_clamp_min: -10, i_clamp_max: 10}
-    $(arg side)_wrist_roll_joint: {p: 15, i: 5, d: 1, i_clamp_min: -50, i_clamp_max: 50}
+    $(arg side)_base_roll_joint: {p: 50, i: 3, d: 3.5, i_clamp_min: -100, i_clamp_max: 100}
+    $(arg side)_shoulder_lift_joint: {p: 40, i: 3, d: 5, i_clamp_min: -30, i_clamp_max: 30}
+    $(arg side)_shoulder_roll_joint: {p: 40, i: 5, d: 4, i_clamp_min: -50, i_clamp_max: 50}
+    $(arg side)_elbow_lift_joint: {p: 40, i: 3, d: 5, i_clamp_min: -10, i_clamp_max: 10}
+    $(arg side)_elbow_roll_joint: {p: 30, i: 7, d: 4, i_clamp_min: -50, i_clamp_max: 50}
+    $(arg side)_wrist_lift_joint: {p: 30, i: 3, d: 2, i_clamp_min: -10, i_clamp_max: 10}
+    $(arg side)_wrist_roll_joint: {p: 25, i: 5, d: 1, i_clamp_min: -50, i_clamp_max: 50}
 
 joint_torque_controller:
   type: effort_controllers/JointGroupEffortController


### PR DESCRIPTION
I've edited the controller.yaml file for better controller gains for the actual arm. They should represent better starting gains for the joint_trajectory_controller.

I tried to tune them for compliance as well as pose accuracy. Currently, if the arm goes very far off, it should be able to correct itself and converge onto the end-effector pose goal within 20-30 seconds, while still being fairly compliant.