### PR TITLE
Feature: Arm helper scripts

### DIFF
--- a/blue_bringup/CMakeLists.txt
+++ b/blue_bringup/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(blue_bringup)
 
-find_package(catkin REQUIRED COMPONENTS)
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  trajectory_msgs
+  control_msgs
+  sensor_msgs
+  actionlib_msgs
+)
 
 ###################################
 ## catkin specific configuration ##

--- a/blue_bringup/launch/include/single_arm_control.launch.xml
+++ b/blue_bringup/launch/include/single_arm_control.launch.xml
@@ -35,8 +35,6 @@
       output="screen">
       <rosparam param="start_controllers">
         - blue_controllers/joint_state_controller
-        - blue_controllers/joint_trajectory_controller
-        - blue_controllers/gripper_controller
       </rosparam>
     </node>
 

--- a/blue_bringup/launch/include/single_arm_control.launch.xml
+++ b/blue_bringup/launch/include/single_arm_control.launch.xml
@@ -35,6 +35,8 @@
       output="screen">
       <rosparam param="start_controllers">
         - blue_controllers/joint_state_controller
+        - blue_controllers/joint_trajectory_controller
+        - blue_controllers/gripper_controller
       </rosparam>
     </node>
 

--- a/blue_bringup/package.xml
+++ b/blue_bringup/package.xml
@@ -12,6 +12,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>rospy</build_depend>
+
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>control_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>blue_controller_manager</exec_depend>
   <exec_depend>blue_msgs</exec_depend>
   <exec_depend>rosbridge_server</exec_depend>

--- a/blue_bringup/scripts/right_home_pose_commander
+++ b/blue_bringup/scripts/right_home_pose_commander
@@ -123,7 +123,7 @@ if __name__ == '__main__':
 
     # Return arm to intermediate home
     rospy.loginfo("Moving Arm to Home")
-    move_arm(pre_startup_joint_positions)
+    move_arm(pre_startup_joint_positions, skip_if_close=False)
 
     # Return arm to home
     move_arm(startup_joint_positions, skip_if_close=False)

--- a/blue_bringup/scripts/right_home_pose_commander
+++ b/blue_bringup/scripts/right_home_pose_commander
@@ -72,13 +72,13 @@ if __name__ == '__main__':
 
     # Populate gripper messages
     open_gripper_command.goal.command.max_effort = 3.0
-    open_gripper_command.goal.command.position = 0.25
+    open_gripper_command.goal.command.position = -0.05
 
     close_gripper_command.goal.command.max_effort = 3.0
-    close_gripper_command.goal.command.position = -2.0
+    close_gripper_command.goal.command.position = 1.05
 
     stop_gripper_command.goal.command.max_effort = 0
-    stop_gripper_command.goal.command.position = 0.25
+    stop_gripper_command.goal.command.position = -0.05
 
     # Set final goal
     final_goal = startup_joint_positions

--- a/blue_bringup/scripts/right_home_pose_commander
+++ b/blue_bringup/scripts/right_home_pose_commander
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+from control_msgs.msg import GripperCommandActionGoal
+from sensor_msgs.msg import JointState
+import std_msgs.msg
+import rosgraph
+import rospy
+
+import numpy as np
+import time
+import copy
+import sys
+
+import signal
+import sys
+
+ARM_NAME = "right"
+ARM_COMMAND_TOPIC = "right_arm/blue_controllers/joint_trajectory_controller/command"
+GRIPPER_COMMAND_TOPIC = "right_arm/blue_controllers/gripper_controller/gripper_cmd/goal"
+ARM_PARAM_NS = "right_arm/blue_hardware/"
+MOVE_WAIT_TIME = 5
+POSITION_SKIP_TOLERANCE = 1
+
+def signal_handler(sig, frame):
+    sys.exit(0)
+
+joint_states = JointState()
+def joint_state_callback(joint_state_msg):
+    global joint_states
+    joint_states = joint_state_msg
+
+def get_rectified_joint_positions(joint_state_msg):
+    indexes = [joint_state_msg.name.index(joint) for joint in joint_names]
+    return np.array([joint_state_msg.position[x] for x in indexes])
+
+if __name__ == '__main__':
+    # Bind interrupt handler
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # Start ROS
+    rospy.init_node(ARM_NAME + '_home_pose_commander')
+    arm_commander = rospy.Publisher(ARM_COMMAND_TOPIC, JointTrajectory, queue_size = 1)
+    gripper_commander = rospy.Publisher(GRIPPER_COMMAND_TOPIC, GripperCommandActionGoal, queue_size = 1)
+    joint_state_sub = rospy.Subscriber("/joint_states", JointState, joint_state_callback)
+
+    rospy.sleep(1) # Allow publisher to bind
+
+    # Guard against too low a delay
+    if MOVE_WAIT_TIME < 3:
+        MOVE_WAIT_TIME = 3
+
+    # Get params
+    startup_joint_positions = np.array(rospy.get_param(ARM_PARAM_NS + "simple_startup_angles"))[:-1]
+    pre_startup_joint_positions = startup_joint_positions.copy()
+    pre_startup_joint_positions[1] = 0.0 # Don't lower shoulder_lift_joint yet
+    pre_startup_joint_positions[5] = -1.0 # Retract wrist_lift_joint to avoid table
+    joint_names = rospy.get_param(ARM_PARAM_NS + "joint_names")[:-1]
+
+    # Set up messages
+    arm_command = JointTrajectory()
+    close_gripper_command = GripperCommandActionGoal()
+    open_gripper_command = GripperCommandActionGoal()
+    stop_gripper_command = GripperCommandActionGoal()
+    trajectory_point = JointTrajectoryPoint()
+
+    # Populate arm messages
+    arm_command.points.append(trajectory_point)
+    arm_command.header = std_msgs.msg.Header()
+    arm_command.joint_names = joint_names
+    arm_command.points[0].time_from_start.secs = MOVE_WAIT_TIME - 1
+
+    # Populate gripper messages
+    open_gripper_command.goal.command.max_effort = 3.0
+    open_gripper_command.goal.command.position = 0.25
+
+    close_gripper_command.goal.command.max_effort = 3.0
+    close_gripper_command.goal.command.position = -2.0
+
+    stop_gripper_command.goal.command.max_effort = 0
+    stop_gripper_command.goal.command.position = 0.25
+
+    # Set final goal
+    final_goal = startup_joint_positions
+
+    # Command Function
+    def move_arm(positions, skip_if_close=True):
+        # Set and publish arm command
+        arm_command.points[0].positions = positions
+
+        if skip_if_close:
+            # If either the final goal or the intermediate goals are close to
+            # the current state of the arm, skip the intermediate goal
+            if np.abs(np.sum(np.abs(get_rectified_joint_positions(joint_states))
+                      - np.abs(final_goal))) < POSITION_SKIP_TOLERANCE:
+                return
+            if np.abs(np.sum(np.abs(get_rectified_joint_positions(joint_states))
+                      - np.abs(positions))) < POSITION_SKIP_TOLERANCE:
+                return
+
+        arm_command.header.stamp = rospy.Time.now()
+        arm_commander.publish(arm_command)
+
+        rospy.sleep(MOVE_WAIT_TIME)
+
+    def stop_arm():
+        stop_command = JointTrajectory()
+        stop_command.joint_names = joint_names
+        stop_command.header.stamp = rospy.Time.now()
+        arm_commander.publish(stop_command)
+
+    ############################################################################
+    # BEGIN ACTUATION
+    ############################################################################
+
+    # Close Gripper
+    rospy.loginfo("Closing grippers")
+    gripper_commander.publish(close_gripper_command)
+
+    # Raise Arm
+    rospy.loginfo("Readying Arm")
+    move_arm(np.zeros(7))
+
+    # Return arm to intermediate home
+    rospy.loginfo("Moving Arm to Home")
+    move_arm(pre_startup_joint_positions)
+
+    # Return arm to home
+    move_arm(startup_joint_positions, skip_if_close=False)
+    rospy.loginfo("Arm has reached Home")
+    rospy.sleep(0.25)
+
+    # Open and Stop Gripper
+    rospy.loginfo("Opening and depowering Grippers")
+    gripper_commander.publish(open_gripper_command)
+    rospy.sleep(3)
+    gripper_commander.publish(stop_gripper_command)
+
+    rospy.sleep(3)
+
+    stop_arm()

--- a/blue_bringup/scripts/right_home_pose_commander
+++ b/blue_bringup/scripts/right_home_pose_commander
@@ -72,13 +72,13 @@ if __name__ == '__main__':
 
     # Populate gripper messages
     open_gripper_command.goal.command.max_effort = 3.0
-    open_gripper_command.goal.command.position = -0.05
+    open_gripper_command.goal.command.position = 0.25
 
     close_gripper_command.goal.command.max_effort = 3.0
-    close_gripper_command.goal.command.position = 1.05
+    close_gripper_command.goal.command.position = -2.0
 
     stop_gripper_command.goal.command.max_effort = 0
-    stop_gripper_command.goal.command.position = -0.05
+    stop_gripper_command.goal.command.position = 0.25
 
     # Set final goal
     final_goal = startup_joint_positions

--- a/blue_bringup/scripts/right_pickup_ready_pose_commander
+++ b/blue_bringup/scripts/right_pickup_ready_pose_commander
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+from control_msgs.msg import GripperCommandActionGoal
+from sensor_msgs.msg import JointState
+import std_msgs.msg
+import rosgraph
+import rospy
+
+import numpy as np
+import time
+import copy
+import sys
+
+import signal
+import sys
+
+ARM_NAME = "right"
+ARM_COMMAND_TOPIC = "right_arm/blue_controllers/joint_trajectory_controller/command"
+GRIPPER_COMMAND_TOPIC = "right_arm/blue_controllers/gripper_controller/gripper_cmd/goal"
+ARM_PARAM_NS = "right_arm/blue_hardware/"
+MOVE_WAIT_TIME = 5
+POSITION_SKIP_TOLERANCE = 1
+
+def signal_handler(sig, frame):
+    sys.exit(0)
+
+joint_states = JointState()
+def joint_state_callback(joint_state_msg):
+    global joint_states
+    joint_states = joint_state_msg
+
+def get_rectified_joint_positions(joint_state_msg):
+    indexes = [joint_state_msg.name.index(joint) for joint in joint_names]
+    return np.array([joint_state_msg.position[x] for x in indexes])
+
+if __name__ == '__main__':
+    # Bind interrupt handler
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # Start ROS
+    rospy.init_node(ARM_NAME + '_startup_pose_commander')
+    arm_commander = rospy.Publisher(ARM_COMMAND_TOPIC, JointTrajectory, queue_size = 1)
+    gripper_commander = rospy.Publisher(GRIPPER_COMMAND_TOPIC, GripperCommandActionGoal, queue_size = 1)
+    joint_state_sub = rospy.Subscriber("/joint_states", JointState, joint_state_callback)
+
+    rospy.sleep(1) # Allow publisher to bind
+
+    # Guard against too low a delay
+    if MOVE_WAIT_TIME < 3:
+        MOVE_WAIT_TIME = 3
+
+    # Get params
+    pickup_ready_joint_positions = np.array([0.0, 0.33, 1.5, -1.6, -1.5, -1.0, 0.0])
+    joint_names = rospy.get_param(ARM_PARAM_NS + "joint_names")[:-1]
+
+    # Set up messages
+    arm_command = JointTrajectory()
+    close_gripper_command = GripperCommandActionGoal()
+    open_gripper_command = GripperCommandActionGoal()
+    stop_gripper_command = GripperCommandActionGoal()
+    trajectory_point = JointTrajectoryPoint()
+
+    # Populate arm messages
+    arm_command.points.append(trajectory_point)
+    arm_command.header = std_msgs.msg.Header()
+    arm_command.joint_names = joint_names
+    arm_command.points[0].time_from_start.secs = MOVE_WAIT_TIME - 1
+
+    # Populate gripper messages
+    open_gripper_command.goal.command.max_effort = 3.0
+    open_gripper_command.goal.command.position = 0.25
+
+    close_gripper_command.goal.command.max_effort = 3.0
+    close_gripper_command.goal.command.position = -2.0
+
+    stop_gripper_command.goal.command.max_effort = 0
+    stop_gripper_command.goal.command.position = 0.25
+
+    # Set final goal
+    final_goal = pickup_ready_joint_positions
+
+    # Command Function
+    def move_arm(positions, skip_if_close=True):
+        # Set and publish arm command
+        arm_command.points[0].positions = positions
+
+        if skip_if_close:
+            # If either the final goal or the intermediate goals are close to
+            # the current state of the arm, skip the intermediate goal
+            if np.abs(np.sum(np.abs(get_rectified_joint_positions(joint_states))
+                      - np.abs(final_goal))) < POSITION_SKIP_TOLERANCE:
+                return
+            if np.abs(np.sum(np.abs(get_rectified_joint_positions(joint_states))
+                      - np.abs(positions))) < POSITION_SKIP_TOLERANCE:
+                return
+
+        arm_command.header.stamp = rospy.Time.now()
+        arm_commander.publish(arm_command)
+
+        rospy.sleep(MOVE_WAIT_TIME)
+
+    ############################################################################
+    # BEGIN ACTUATION
+    ############################################################################
+
+    # Close Gripper
+    rospy.loginfo("Closing grippers")
+    gripper_commander.publish(close_gripper_command)
+
+    # Raise Arm
+    rospy.loginfo("Readying arm")
+    move_arm(np.zeros(7))
+
+    # Move Arm to Pickup-Ready Position
+    rospy.loginfo("Moving arm to Pickup-Ready Position")
+    move_arm(pickup_ready_joint_positions, skip_if_close=False)
+    rospy.loginfo("Arm is ready")
+    rospy.sleep(0.25)
+
+    # Open and Stop Gripper
+    rospy.loginfo("Opening and Depowering grippers")
+    gripper_commander.publish(open_gripper_command)
+    rospy.sleep(3)
+    gripper_commander.publish(stop_gripper_command)

--- a/blue_bringup/setup.py
+++ b/blue_bringup/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+setup_args = generate_distutils_setup(
+    packages = ['blue_bringup'],
+    package_dir = {'': 'scripts'},
+    install_requires = ['']
+)
+
+setup(**setup_args)


### PR DESCRIPTION
### Description
It can get quite tiring to have to keep manually resetting the arm to retune its controllers, so I wrote some scripts to return the arm to its home position and send it out again to a pickup-ready position. This needs to be done because commanding the arm through the MoveIt! interface will cause the planner to think that it is colliding with itself and abort the command.

The arm home position is gotten from the startup angles parameters. The individual scripts have other tunable variables, but I don't expect them to need changing.

Also, the script has an inbuilt intermediate goal skipping check implemented. The arm will skip an intermediate goal if its current position is already close to it or the final goal.

### Notes
I only included scripts for a right arm since that's the only one I could test on. Implementing the scripts for left arms should be a fairly easy matter of changing the topic names.

Note that no collision avoidance will occur when using these scripts.

I also made the controllers turn on by default since the scripts can then go ahead and control the arm.