### PR TITLE
Bugfix: Correct v1 joint limits

### DIFF
--- a/blue_descriptions/urdf/link_v1/link.urdf.xacro
+++ b/blue_descriptions/urdf/link_v1/link.urdf.xacro
@@ -63,8 +63,8 @@
       <axis
         xyz="0 0 1" />
       <limit
-        lower="-2.2944"
-        upper="0"
+        lower="-2.3911"
+        upper="0.3316"
         effort="800"
         velocity="50" />
     </joint>


### PR DESCRIPTION
I found that the joint limits specified in the V1 URDF are a lot more conservative than the arm allows, which causes issues with planning. This PR fixes that.